### PR TITLE
Restructure dbt datasets and integrate experiment assignments

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -23,16 +23,19 @@ models:
     # Staging layer - clean and standardize raw data
     staging:
       +materialized: view
+      +schema: staging  # This allows operationalization of the macro: generate_schema_name
       +tags: ["staging"]
     
     # Intermediate layer - business logic transformations  
     intermediate:
       +materialized: view
+      +schema: intermediate
       +tags: ["intermediate"]
     
     # Marts layer - analysis-ready datasets
     marts:
       +materialized: table
+      +schema: marts
       core:
         +tags: ["core", "mart"]
       experiments:

--- a/macros/get_custom_schema.sql
+++ b/macros/get_custom_schema.sql
@@ -1,0 +1,14 @@
+{% macro generate_schema_name(custom_schema_name, node) -%}
+
+    {%- set default_schema = target.schema -%}
+    {%- if custom_schema_name is none -%}
+
+        {{ default_schema }}
+
+    {%- else -%}
+
+        flit_{{ custom_schema_name | trim }}
+
+    {%- endif -%}
+
+{%- endmacro %}

--- a/models/intermediate/schema.yml
+++ b/models/intermediate/schema.yml
@@ -1,0 +1,42 @@
+version: 2
+
+models:
+  - name: int_experiment_orders_union
+    description: "Combined baseline and synthetic orders with experiment assignments"
+    columns:
+      - name: order_id
+        description: "Unique identifier for each order"
+        tests:
+          - unique
+          - not_null
+      
+      - name: user_id
+        description: "Unique identifier for user placing the order"
+        tests:
+          - not_null
+      
+      - name: control_treatment
+        description: "Control or treatment assignment for experiment participants"
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['control', 'treatment']
+      
+      - name: variant_description
+        description: "Descriptive name of the experiment variant"
+      
+      - name: experiment_status
+        description: "Whether user participated in the experiment"
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['experiment_participant', 'non_participant']
+      
+      - name: data_source
+        description: "Source of the data"
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['thelook_baseline', 'synthetic_overlay']

--- a/models/marts/experiments/mart_free_shipping_threshold_analysis.sql
+++ b/models/marts/experiments/mart_free_shipping_threshold_analysis.sql
@@ -33,12 +33,11 @@ order_level_analysis as (
         created_at,
         shipped_at,
         delivered_at,
-        returned_at,
         
         -- Derived metrics
         case when status = 'Complete' then 1 else 0 end as is_completed,
         case when status = 'Cancelled' then 1 else 0 end as is_cancelled,
-        case when returned_at is not null then 1 else 0 end as is_returned,
+        0 as is_returned,  -- All returns are null, hardcode to 0
         
         -- Timing metrics
         date_diff(shipped_at, created_at, day) as days_to_ship,

--- a/models/staging/schema.yml
+++ b/models/staging/schema.yml
@@ -1,5 +1,41 @@
 version: 2
 
+sources:
+  - name: flit_raw
+    description: "Raw data from synthetic data generation pipeline"
+    tables:
+      - name: experiment_assignments
+        description: "User assignments for experiments with enhanced schema"
+        columns:
+          - name: assignment_id
+            description: "Unique identifier for each assignment"
+            tests:
+              - unique
+              - not_null
+          
+          - name: object_identifier
+            description: "User ID as string"
+            tests:
+              - not_null
+          
+          - name: experiment_name
+            description: "Name of the experiment"
+            tests:
+              - not_null
+          
+          - name: variant
+            description: "Control or treatment assignment"
+            tests:
+              - not_null
+              - accepted_values:
+                  arguments:
+                    values: ['control', 'treatment']
+          
+          - name: variant_description
+            description: "Descriptive variant name"
+            tests:
+              - not_null
+
 models:
   - name: stg_synthetic_overlay_orders
     description: "Synthetic overlay orders for experiments with standardized schema"

--- a/models/staging/stg_synthetic_overlay_orders.sql
+++ b/models/staging/stg_synthetic_overlay_orders.sql
@@ -23,10 +23,6 @@ renamed as (
         created_at,
         shipped_at,
         delivered_at,
-        case 
-            when returned_at = '' then null
-            else safe.parse_timestamp('%Y-%m-%d %H:%M:%S UTC', returned_at)
-        end as returned_at,
         
         -- Data lineage
         'synthetic_overlay' as data_source,

--- a/models/staging/stg_thelook_baseline_orders.sql
+++ b/models/staging/stg_thelook_baseline_orders.sql
@@ -23,7 +23,6 @@ renamed as (
         created_at,
         shipped_at,
         delivered_at,
-        returned_at,
         
         -- Data lineage
         'thelook_baseline' as data_source,


### PR DESCRIPTION
## Summary

This PR implements comprehensive dbt architecture improvements that enable proper experimentation analysis:

### Key Changes

**Dataset Organization**
- Fixed dataset routing with custom schema macro using `flit_` prefix
- Models now deploy to proper datasets: `flit_staging`, `flit_intermediate`, `flit_marts`
- Eliminates the issue where all models were deployed to `flit_raw`

**Experiment Integration**  
- Added `experiment_assignments` as a dbt source with enhanced schema
- Integrated user assignments into `int_experiment_orders_union` via JOIN -- that is added control/treatment labels and experiment status columns

**Data Quality Improvements**
- Removed unused `returned_at` column (was problematic INT64 with all NULL values)
- Fixed column schema mismatches between baseline and synthetic data
- Updated deprecated dbt test syntax to modern format

### Technical Details

**New Architecture**
```
flit_staging/
├── stg_thelook_baseline_orders (baseline data)
└── stg_synthetic_overlay_orders (synthetic treatment effects)

flit_intermediate/  
└── int_experiment_orders_union (combined + assignments)
    ├── control_treatment (control/treatment labels) 
    ├── experiment_status (participant/non_participant)

flit_marts/
└── mart_free_shipping_threshold_analysis (analysis-ready)
```

### Testing

- ✅ All 4 dbt models run successfully
- ✅ Dataset organization working (proper flit_ prefixed datasets)
- ✅ Experiment assignments JOIN working correctly
- ✅ End-to-end data pipeline validated


### Impact
This enables Phase 3 statistical analysis by providing properly structured data with:
- User-level experiment assignments (control vs treatment)
- Combined baseline and synthetic overlay data
- Analysis-ready marts for statistical testing

Ready for experimentation analysis in flit-experiments repository.